### PR TITLE
Bump up default Read/Write capacity units

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -57,5 +57,5 @@ resources:
           - AttributeName: reservation
             KeyType: RANGE
         ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+          ReadCapacityUnits: 25
+          WriteCapacityUnits: 5


### PR DESCRIPTION
As reported in #12, it's possible that we can get throttled when
deleting multiple check-ins which occur around the same time.

Anything under 10w/50r seems to be billed the same for DynamoDB:

https://aws.amazon.com/dynamodb/pricing/