### PR TITLE
Only schedule future checkins (again)

### DIFF
--- a/lambda/lib/swa.py
+++ b/lambda/lib/swa.py
@@ -17,6 +17,10 @@ API_KEY = "l7xx8d8bfce4ee874269bedc02832674129b"
 class Reservation():
     def __init__(self, data):
         self.data = data
+        self.confirmation_number = self.data['recordLocator']
+
+    def __repr__(self):
+        return "<Reservation {}>".format(self.confirmation_number)
 
     @classmethod
     def from_passenger_info(cls, first_name, last_name, confirmation_number):

--- a/lambda/lib/swa.py
+++ b/lambda/lib/swa.py
@@ -47,11 +47,13 @@ class Reservation():
         """
         return pendulum.parse(departure_time).subtract(days=1)
 
+
     @property
-    def check_in_times(self):
+    def check_in_times(self, expired=False):
         """
         Return a sorted and reversed list of check-in times for a reservation as
-        RFC3339 timestamps.
+        RFC3339 timestamps. By default, only future checkin times are returned.
+        Set `expired` to True to return all checkin times.
 
         Times are sorted and reversed so that the soonest check-in time may be
         popped from the end of the list.
@@ -63,6 +65,10 @@ class Reservation():
             self._get_check_in_time(flight['segments'][0]['departureDateTime'])
             for flight in flights
         ]
+
+        # Remove expired checkins from results
+        if not expired:
+            times = filter(lambda x: x > pendulum.now(), times)
 
         return list(map(str, reversed(sorted(times))))
 

--- a/lambda/tests/fixtures/get_multi_passenger_reservation.json
+++ b/lambda/tests/fixtures/get_multi_passenger_reservation.json
@@ -17,13 +17,13 @@
         {
           "earlyBirdProductId": "QVVTfDIwMTctMDUtMTN8NDE4MHxBTEVYQU5EUkF8TUlMTEVSfEJBU1N8fDE1MDA=",
           "status": "ELIGIBLE",
-          "originationDestinationId": "201705130855-0500,201705131050-0500|AUS-MCI|WN4180",
+          "originationDestinationId": "209905130855-0500,209905131050-0500|AUS-MCI|WN4180",
           "priceCents": 1500
         },
         {
           "earlyBirdProductId": "TUNJfDIwMTctMDUtMTR8NDExNnxBTEVYQU5EUkF8TUlMTEVSfEJBU1N8fDE1MDA=",
           "status": "ELIGIBLE",
-          "originationDestinationId": "201705141510-0500,201705141715-0500|MCI-AUS|WN4116",
+          "originationDestinationId": "209905141510-0500,209905141715-0500|MCI-AUS|WN4116",
           "priceCents": 1500
         }
       ],
@@ -46,13 +46,13 @@
         {
           "earlyBirdProductId": "QVVTfDIwMTctMDUtMTN8NDE4MHxEQVZJU3xIQUxFfEJBU1N8fDE1MDA=",
           "status": "ELIGIBLE",
-          "originationDestinationId": "201705130855-0500,201705131050-0500|AUS-MCI|WN4180",
+          "originationDestinationId": "209905130855-0500,209905131050-0500|AUS-MCI|WN4180",
           "priceCents": 1500
         },
         {
           "earlyBirdProductId": "TUNJfDIwMTctMDUtMTR8NDExNnxEQVZJU3xIQUxFfEJBU1N8fDE1MDA=",
           "status": "ELIGIBLE",
-          "originationDestinationId": "201705141510-0500,201705141715-0500|MCI-AUS|WN4116",
+          "originationDestinationId": "209905141510-0500,209905141715-0500|MCI-AUS|WN4116",
           "priceCents": 1500
         }
       ],
@@ -91,7 +91,7 @@
               "flightNumber": "4180"
             },
             "originationAirportCode": "AUS",
-            "departureDateTime": "2017-05-13T08:55:00.000-05:00",
+            "departureDateTime": "2099-05-13T08:55:00.000-05:00",
             "legs": [
               {
                 "destinationAirportCode": "MCI",
@@ -100,7 +100,7 @@
             ],
             "destinationAirportCode": "MCI",
             "wifiAvailable": null,
-            "arrivalDateTime": "2017-05-13T10:50:00.000-05:00"
+            "arrivalDateTime": "2099-05-13T10:50:00.000-05:00"
           }
         ],
         "_links": {
@@ -108,7 +108,7 @@
         },
         "checkinDocumentReason": null,
         "fareType": "Wanna Get Away",
-        "originationDestinationId": "201705130855-0500,201705131050-0500|AUS-MCI|WN4180"
+        "originationDestinationId": "209905130855-0500,209905131050-0500|AUS-MCI|WN4180"
       },
       {
         "durationMinutes": 125,
@@ -124,7 +124,7 @@
               "flightNumber": "4116"
             },
             "originationAirportCode": "MCI",
-            "departureDateTime": "2017-05-14T15:10:00.000-05:00",
+            "departureDateTime": "2099-05-14T15:10:00.000-05:00",
             "legs": [
               {
                 "destinationAirportCode": "AUS",
@@ -133,7 +133,7 @@
             ],
             "destinationAirportCode": "AUS",
             "wifiAvailable": null,
-            "arrivalDateTime": "2017-05-14T17:15:00.000-05:00"
+            "arrivalDateTime": "2099-05-14T17:15:00.000-05:00"
           }
         ],
         "_links": {
@@ -141,7 +141,7 @@
         },
         "checkinDocumentReason": null,
         "fareType": "Wanna Get Away",
-        "originationDestinationId": "201705141510-0500,201705141715-0500|MCI-AUS|WN4116"
+        "originationDestinationId": "209905141510-0500,209905141715-0500|MCI-AUS|WN4116"
       }
     ]
   },

--- a/lambda/tests/fixtures/get_reservation.json
+++ b/lambda/tests/fixtures/get_reservation.json
@@ -17,13 +17,13 @@
                 {
                     "earlyBirdProductId": "QVVTfDIwMTctMDgtMTh8NjIxNnxEQVZJRHxMfFdJVFRNQU58SlJ8MTUwMA==",
                     "status": "ELIGIBLE",
-                    "originationDestinationId": "201708181850-0500,201708182050-0500|AUS-BNA|WN6216",
+                    "originationDestinationId": "209908181850-0500,209908182050-0500|AUS-BNA|WN6216",
                     "priceCents": 1500
                 },
                 {
                     "earlyBirdProductId": "Qk5BfDIwMTctMDgtMjJ8MTk2NHxEQVZJRHxMfFdJVFRNQU58SlJ8MTUwMA==",
                     "status": "ELIGIBLE",
-                    "originationDestinationId": "201708220735-0500,201708220945-0500|BNA-AUS|WN1964",
+                    "originationDestinationId": "209908220735-0500,209908220945-0500|BNA-AUS|WN1964",
                     "priceCents": 1500
                 }
             ],
@@ -62,7 +62,7 @@
                             "flightNumber": "6216"
                         },
                         "originationAirportCode": "AUS",
-                        "departureDateTime": "2017-08-18T18:50:00.000-05:00",
+                        "departureDateTime": "2099-08-18T18:50:00.000-05:00",
                         "legs": [
                             {
                                 "destinationAirportCode": "BNA",
@@ -71,7 +71,7 @@
                         ],
                         "destinationAirportCode": "BNA",
                         "wifiAvailable": null,
-                        "arrivalDateTime": "2017-08-18T20:50:00.000-05:00"
+                        "arrivalDateTime": "2099-08-18T20:50:00.000-05:00"
                     }
                 ],
                 "_links": {
@@ -79,7 +79,7 @@
                 },
                 "checkinDocumentReason": null,
                 "fareType": "Wanna Get Away",
-                "originationDestinationId": "201708181850-0500,201708182050-0500|AUS-BNA|WN6216"
+                "originationDestinationId": "209908181850-0500,209908182050-0500|AUS-BNA|WN6216"
             },
             {
                 "durationMinutes": 130,
@@ -95,7 +95,7 @@
                             "flightNumber": "1964"
                         },
                         "originationAirportCode": "BNA",
-                        "departureDateTime": "2017-08-22T07:35:00.000-05:00",
+                        "departureDateTime": "2099-08-22T07:35:00.000-05:00",
                         "legs": [
                             {
                                 "destinationAirportCode": "AUS",
@@ -104,7 +104,7 @@
                         ],
                         "destinationAirportCode": "AUS",
                         "wifiAvailable": null,
-                        "arrivalDateTime": "2017-08-22T09:45:00.000-05:00"
+                        "arrivalDateTime": "2099-08-22T09:45:00.000-05:00"
                     }
                 ],
                 "_links": {
@@ -112,7 +112,7 @@
                 },
                 "checkinDocumentReason": null,
                 "fareType": "Wanna Get Away",
-                "originationDestinationId": "201708220735-0500,201708220945-0500|BNA-AUS|WN1964"
+                "originationDestinationId": "209908220735-0500,209908220945-0500|BNA-AUS|WN1964"
             }
         ]
     },

--- a/lambda/tests/test_handler.py
+++ b/lambda/tests/test_handler.py
@@ -27,8 +27,8 @@ class TestScheduleCheckIn(unittest.TestCase):
             ],
             'confirmation_number': 'ABC123',
             'check_in_times': {
-                'remaining': ['2017-08-21T07:35:00-05:00'],
-                'next': '2017-08-17T18:50:00-05:00'
+                'remaining': ['2099-08-21T07:35:00-05:00'],
+                'next': '2099-08-17T18:50:00-05:00'
             },
             'email': 'gwb@aol.com'
         }
@@ -52,8 +52,8 @@ class TestScheduleCheckIn(unittest.TestCase):
             ],
             'confirmation_number': 'ABC123',
             'check_in_times': {
-                'remaining': ['2017-05-13T15:10:00-05:00'],
-                'next': '2017-05-12T08:55:00-05:00'
+                'remaining': ['2099-05-13T15:10:00-05:00'],
+                'next': '2099-05-12T08:55:00-05:00'
             },
             'email': 'gwb@aol.com'
         }

--- a/lambda/tests/test_swa.py
+++ b/lambda/tests/test_swa.py
@@ -141,4 +141,4 @@ class TestReservation(unittest.TestCase):
     def test_check_in_times(self):
         fixture = util.load_fixture('get_reservation')
         r = swa.Reservation(fixture)
-        assert r.check_in_times == ['2017-08-21T07:35:00-05:00', '2017-08-17T18:50:00-05:00']
+        assert r.check_in_times == ['2099-08-21T07:35:00-05:00', '2099-08-17T18:50:00-05:00']

--- a/lambda/tests/test_swa.py
+++ b/lambda/tests/test_swa.py
@@ -142,3 +142,8 @@ class TestReservation(unittest.TestCase):
         fixture = util.load_fixture('get_reservation')
         r = swa.Reservation(fixture)
         assert r.check_in_times == ['2099-08-21T07:35:00-05:00', '2099-08-17T18:50:00-05:00']
+
+    def test_confirmation_number(self):
+        fixture = util.load_fixture('get_reservation')
+        r = swa.Reservation(fixture)
+        assert r.confirmation_number == "ABC123"


### PR DESCRIPTION
This got lost in the shuffle when converting from DynamoDB to Step
functions. Filter out expired checkins by default.

Modifies fixtures to return checkin times in 2099 so they're never
expired. Well, within reason. God help us all if those code is still in
use in 2099.