### PR TITLE
[lambda] Allow for setting check in second

### DIFF
--- a/lambda/lib/swa.py
+++ b/lambda/lib/swa.py
@@ -18,6 +18,8 @@ class Reservation():
     def __init__(self, data):
         self.data = data
         self.confirmation_number = self.data['recordLocator']
+        # Second of the minute to use for check in times
+        self.check_in_seconds = 5
 
     def __repr__(self):
         return "<Reservation {}>".format(self.confirmation_number)
@@ -48,10 +50,12 @@ class Reservation():
             2017-02-09T07:50:00.000-06:00
 
         And returns the check in time (24 hours prior) as a pendulum time
-        object. One second is added to the checkin time, as it seems most
-        checkins which occur exactly on the minute fail.
+        object. `self.check_in_seconds` seconds (Default 5) are added to
+        the checkin time to allow for some clock skew buffer.
         """
-        return pendulum.parse(departure_time).subtract(days=1).add(seconds=1)
+        return pendulum.parse(departure_time)\
+                .subtract(days=1)\
+                .add(seconds=self.check_in_seconds)
 
 
     @property

--- a/lambda/tests/test_handler.py
+++ b/lambda/tests/test_handler.py
@@ -27,8 +27,8 @@ class TestScheduleCheckIn(unittest.TestCase):
             ],
             'confirmation_number': 'ABC123',
             'check_in_times': {
-                'remaining': ['2099-08-21T07:35:01-05:00'],
-                'next': '2099-08-17T18:50:01-05:00'
+                'remaining': ['2099-08-21T07:35:05-05:00'],
+                'next': '2099-08-17T18:50:05-05:00'
             },
             'email': 'gwb@example.com'
         }
@@ -52,8 +52,8 @@ class TestScheduleCheckIn(unittest.TestCase):
             ],
             'confirmation_number': 'ABC123',
             'check_in_times': {
-                'remaining': ['2099-05-13T15:10:01-05:00'],
-                'next': '2099-05-12T08:55:01-05:00'
+                'remaining': ['2099-05-13T15:10:05-05:00'],
+                'next': '2099-05-12T08:55:05-05:00'
             },
             'email': 'gwb@example.com'
         }

--- a/lambda/tests/test_swa.py
+++ b/lambda/tests/test_swa.py
@@ -141,7 +141,13 @@ class TestReservation(unittest.TestCase):
     def test_check_in_times(self):
         fixture = util.load_fixture('get_reservation')
         r = swa.Reservation(fixture)
-        assert r.check_in_times == ['2099-08-21T07:35:01-05:00', '2099-08-17T18:50:01-05:00']
+        assert r.check_in_times == ['2099-08-21T07:35:05-05:00', '2099-08-17T18:50:05-05:00']
+
+    def test_check_in_times_alternate_second(self):
+        fixture = util.load_fixture('get_reservation')
+        r = swa.Reservation(fixture)
+        r.check_in_seconds = 42
+        assert r.check_in_times == ['2099-08-21T07:35:42-05:00', '2099-08-17T18:50:42-05:00']
 
     def test_confirmation_number(self):
         fixture = util.load_fixture('get_reservation')


### PR DESCRIPTION
Allows for manually overriding the second which checkins should be
scheduled. Defaults to 5 seconds, meaning a checkin which starts at
11:15:00 would actually take place at 11:15:05.