### PR TITLE
[lambda] Reraise errors when scraping email

### DIFF
--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -166,7 +166,7 @@ def receive_email(event, context):
         log.info("Found reservation: {}".format(reservation))
     except Exception as e:
         log.error("Error scraping email {}: {}".format(ses_msg.message_id, e))
-        return
+        raise
 
     # Don't add the email if it's straight from southwest.com
     if not ses_msg.from_email.endswith('southwest.com'):


### PR DESCRIPTION
This allows us to view metrics on errored invocations of the receive
email Lambda function. However, it does mean that the function will be
retried multiple times every time an incorrect email is sent.

For #33