### PR TITLE
Add parser support for middle names and suffix

### DIFF
--- a/lambda/lib/email.py
+++ b/lambda/lib/email.py
@@ -157,17 +157,9 @@ def find_name_and_confirmation_number(msg):
     # Try to match `(5OK3YZ) | 22APR17 | HOU-MDW | Bush/George`
     legacy_email_subject_match = re.search(r"\(([A-Z0-9]{6})\).*\| (\w+ ?\w+\/\w+)", msg.subject)
 
-    # fwd: George Bush's 12/25 Boston Logan trip (ABC123)
-    # Fwd: George Bush's 12/25 Boston Logan trip (ABC123)
-    # George Walker Bush's 12/25 Detroit trip (ABC123)
-    # George W Bush's 12/25 Detroit trip (ABC123)
-    # George W JR Bush's 12/25 Detroit trip (ABC123)
+    # This matches a variety of new email formats which look like
     # George Bush's 12/25 Detroit trip (ABC123)
-    # Steve Mc Lovin's 12/25 Boston Logan trip (ABC123)
-    # George W. Bush's 12/25 Detroit trip (ABC123)
-    # George W Jr. Bush's 12/25 Detroit trip (ABC123)
-    # George W. Jr. Bush's 12/25 Detroit trip (ABC123)
-    new_email_subject_match = re.search(r"[Ffwd:]* *(\w+)* *\w*.*\w*.* (\w+)'s.*\(([A-Z0-9]{6})\)", msg.subject)
+    new_email_subject_match = re.search(r"(?:[Ff]wd: )?(\w+).* (\w+)'s.*\(([A-Z0-9]{6})\)", msg.subject)
 
     # ABC123 George Bush
     manual_email_subject_match = re.search(r"([A-Z0-9]{6})\s+(\w+) (\w+ ?\w+)", msg.subject)

--- a/lambda/lib/email.py
+++ b/lambda/lib/email.py
@@ -155,12 +155,22 @@ def find_name_and_confirmation_number(msg):
     fname, lname, reservation = None, None, None
 
     # Try to match `(5OK3YZ) | 22APR17 | HOU-MDW | Bush/George`
-    match = re.search(r"\(([A-Z0-9]{6})\).*\| (\w+ ?\w+\/\w+)", msg.subject)
+    legacy_email_subject_match = re.search(r"\(([A-Z0-9]{6})\).*\| (\w+ ?\w+\/\w+)", msg.subject)
 
-    if match:
-        log.debug("Found a reservation email: {}".format(msg.subject))
-        reservation = match.group(1)
-        lname, fname = match.group(2).split('/')
+    # George Bush's 12/25 Detroit trip (ABC123)
+    # George W Bush's 12/25 Detroit trip (ABC123)
+    # George Walker Bush's 12/25 Detroit trip (ABC123)
+    # George W Jr Bush's 12/25 Detroit trip (ABC123)
+    # Always creates 5 capture groups: first name, middle name, suffix, last name, reservation
+    new_email_subject_match = re.search(r"(\w+) *(\w+)? *(\w+)? (\w+)'s.*\(([A-Z0-9]{6})\)", msg.subject)
+
+    # ABC123 George Bush
+    manual_email_subject_match = re.search(r"([A-Z0-9]{6})\s+(\w+) (\w+ ?\w+)", msg.subject)
+
+    if legacy_email_subject_match:
+        log.debug("Found a legacy reservation email: {}".format(msg.subject))
+        reservation = legacy_email_subject_match.group(1)
+        lname, fname = legacy_email_subject_match.group(2).split('/')
 
     elif "Here's your itinerary!" in msg.subject:
         log.debug("Found an itinerary email: {}".format(msg.subject))
@@ -194,22 +204,19 @@ def find_name_and_confirmation_number(msg):
             reservation = match.group(1)
             lname, fname = match.group(2).strip().split('/')
 
-    # George Bush's 12/25 Detroit trip (ABC123)
-    # TODO: Doing this search twice is kind of silly
-    elif re.search(r"(\w+) (\w+ ?\w+)'s.*\(([A-Z0-9]{6})\)", msg.subject):
-        match = re.search(r"(\w+) (\w+ ?\w+)'s.*\(([A-Z0-9]{6})\)", msg.subject)
-        if match:
-            fname = match.group(1)
-            lname = match.group(2)
-            reservation = match.group(3)
+    elif new_email_subject_match:
+        log.debug("Found new email subject match: {}".format(msg.subject))
+        fname = new_email_subject_match.group(1)
+        mname = new_email_subject_match.group(2)  # omit middle name
+        suffix = new_email_subject_match.group(3)  # omit suffix
+        lname = new_email_subject_match.group(4)
+        reservation = new_email_subject_match.group(5)
 
-    # ABC123 George Bush
-    # TODO: Doing this search twice is kind of silly
-    elif re.search(r"([A-Z0-9]{6})\s+(\w+) (\w+ ?\w+)", msg.subject):
-        match = re.search(r"([A-Z0-9]{6})\s+(\w+) (\w+ ?\w+)", msg.subject)
-        reservation = match.group(1)
-        fname = match.group(2)
-        lname = match.group(3)
+    elif manual_email_subject_match:
+        log.debug("Found manual email subject match: {}".format(msg.subject))
+        reservation = manual_email_subject_match.group(1)
+        fname = manual_email_subject_match.group(2)
+        lname = manual_email_subject_match.group(3)
 
     if not all([fname, lname, reservation]):
         raise exceptions.ReservationNotFoundError("Unable to find reservation "

--- a/lambda/lib/email.py
+++ b/lambda/lib/email.py
@@ -157,12 +157,17 @@ def find_name_and_confirmation_number(msg):
     # Try to match `(5OK3YZ) | 22APR17 | HOU-MDW | Bush/George`
     legacy_email_subject_match = re.search(r"\(([A-Z0-9]{6})\).*\| (\w+ ?\w+\/\w+)", msg.subject)
 
-    # George Bush's 12/25 Detroit trip (ABC123)
-    # George W Bush's 12/25 Detroit trip (ABC123)
+    # fwd: George Bush's 12/25 Boston Logan trip (ABC123)
+    # Fwd: George Bush's 12/25 Boston Logan trip (ABC123)
     # George Walker Bush's 12/25 Detroit trip (ABC123)
-    # George W Jr Bush's 12/25 Detroit trip (ABC123)
-    # Always creates 5 capture groups: first name, middle name, suffix, last name, reservation
-    new_email_subject_match = re.search(r"(\w+) *(\w+)? *(\w+)? (\w+)'s.*\(([A-Z0-9]{6})\)", msg.subject)
+    # George W Bush's 12/25 Detroit trip (ABC123)
+    # George W JR Bush's 12/25 Detroit trip (ABC123)
+    # George Bush's 12/25 Detroit trip (ABC123)
+    # Steve Mc Lovin's 12/25 Boston Logan trip (ABC123)
+    # George W. Bush's 12/25 Detroit trip (ABC123)
+    # George W Jr. Bush's 12/25 Detroit trip (ABC123)
+    # George W. Jr. Bush's 12/25 Detroit trip (ABC123)
+    new_email_subject_match = re.search(r"[Ffwd:]* *(\w+)* *\w*.*\w*.* (\w+)'s.*\(([A-Z0-9]{6})\)", msg.subject)
 
     # ABC123 George Bush
     manual_email_subject_match = re.search(r"([A-Z0-9]{6})\s+(\w+) (\w+ ?\w+)", msg.subject)
@@ -207,10 +212,8 @@ def find_name_and_confirmation_number(msg):
     elif new_email_subject_match:
         log.debug("Found new email subject match: {}".format(msg.subject))
         fname = new_email_subject_match.group(1)
-        mname = new_email_subject_match.group(2)  # omit middle name
-        suffix = new_email_subject_match.group(3)  # omit suffix
-        lname = new_email_subject_match.group(4)
-        reservation = new_email_subject_match.group(5)
+        lname = new_email_subject_match.group(2)
+        reservation = new_email_subject_match.group(3)
 
     elif manual_email_subject_match:
         log.debug("Found manual email subject match: {}".format(msg.subject))

--- a/lambda/tests/test_email.py
+++ b/lambda/tests/test_email.py
@@ -99,12 +99,16 @@ class TestSendEmail(unittest.TestCase):
 
     def test_find_new_reservation_email(self):
         test_subjects = [
+            'fwd: George Bush\'s 12/25 Boston Logan trip (ABC123): Your reservation is confirmed.',
             'Fwd: George Bush\'s 12/25 Boston Logan trip (ABC123): Your reservation is confirmed.',
-            'George Bush\'s 12/25 Boston Logan trip (ABC123): Your change is confirmed.',
-            'George Bush\'s 12/25 Boston Logan trip (ABC123)',
-            "George Walker Bush's 12/25 Boston Logan trip (ABC123)",
-            "George W Bush's 12/25 Boston Logan trip (ABC123)",
-            "George W JR Bush's 12/25 Detroit trip (ABC123)"
+            'George Bush\'s 12/25 Boston Logan trip (ABC123): Your change is confirmed.'
+            'George Bush\'s 12/25 Detroit trip (ABC123)',
+            'George Walker Bush\'s 12/25 Detroit trip (ABC123)',
+            'George W Bush\'s 12/25 Detroit trip (ABC123)',
+            'George W JR Bush\'s 12/25 Detroit trip (ABC123)',
+            'George W. Bush\'s 12/25 Detroit trip (ABC123)',
+            'George W Jr. Bush\'s 12/25 Detroit trip (ABC123)',
+            'George W. Jr. Bush\'s 12/25 Detroit trip (ABC123)'
         ]
 
         for subject in test_subjects:

--- a/lambda/tests/test_email.py
+++ b/lambda/tests/test_email.py
@@ -101,7 +101,10 @@ class TestSendEmail(unittest.TestCase):
         test_subjects = [
             'Fwd: George Bush\'s 12/25 Boston Logan trip (ABC123): Your reservation is confirmed.',
             'George Bush\'s 12/25 Boston Logan trip (ABC123): Your change is confirmed.',
-            'George Bush\'s 12/25 Boston Logan trip (ABC123)'
+            'George Bush\'s 12/25 Boston Logan trip (ABC123)',
+            "George Walker Bush's 12/25 Boston Logan trip (ABC123)",
+            "George W Bush's 12/25 Boston Logan trip (ABC123)",
+            "George W JR Bush's 12/25 Detroit trip (ABC123)"
         ]
 
         for subject in test_subjects:
@@ -109,16 +112,6 @@ class TestSendEmail(unittest.TestCase):
             expected = dict(first_name="George", last_name="Bush", confirmation_number="ABC123")
             result = email.find_name_and_confirmation_number(e)
             assert result == expected
-
-    def test_find_new_reservation_email_with_space(self):
-        e = FakeEmail(
-            'Fwd: Steve Mc Lovin\'s 12/25 Boston Logan trip (ABC123): Your reservation is confirmed.',
-            0,
-            util.load_fixture('new_reservation_email')
-        )
-        expected = dict(first_name="Steve", last_name="Mc Lovin", confirmation_number="ABC123")
-        result = email.find_name_and_confirmation_number(e)
-        assert result == expected
 
     def test_find_name_and_confirmation_number_shortcut(self):
         e = FakeEmail('ABC123 George Bush', 0)

--- a/lambda/tests/test_email.py
+++ b/lambda/tests/test_email.py
@@ -115,7 +115,7 @@ class TestSendEmail(unittest.TestCase):
             e = FakeEmail(subject, 0, util.load_fixture('new_reservation_email'))
             expected = dict(first_name="George", last_name="Bush", confirmation_number="ABC123")
             result = email.find_name_and_confirmation_number(e)
-            assert result == expected
+            assert result == expected, "Failed subject: {}".format(subject)
 
     def test_find_name_and_confirmation_number_shortcut(self):
         e = FakeEmail('ABC123 George Bush', 0)


### PR DESCRIPTION
I had to remove support for spaces in last names as its impossible to tell them apart from middle names, middle initial, or a suffix. 

In the following example `Mc` will now be omitted as the middle name (verified it is not needed to look up reservations):

`Steve Mc Lovin's 12/25 Boston Logan trip (ABC123)`

Any ideas on how to solve both?

I made quite a few changes, let me know if you want me to revert anything :)
