### PR TITLE
Api base url has changed

### DIFF
--- a/lambda/lib/swa.py
+++ b/lambda/lib/swa.py
@@ -10,7 +10,7 @@ import requests
 
 from . import exceptions
 
-BASE_URL = "https://api-extensions.southwest.com/v1/mobile"
+BASE_URL = "https://mobile.southwest.com/api/extensions/v1/mobile"
 USER_AGENT = "Southwest/4.9.1 CFNetwork/887 Darwin/17.0.0"
 # This is not a secret, but obfuscate it to prevent detection
 API_KEY = codecs.decode("y7kk82o3qo91r6624pp1n690305qqo21279n", "rot13")

--- a/lambda/tests/test_handler.py
+++ b/lambda/tests/test_handler.py
@@ -40,7 +40,7 @@ class TestScheduleCheckIn(unittest.TestCase):
 
         responses.add(
             responses.GET,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/record-locator/ABC123',
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/record-locator/ABC123',
             json=util.load_fixture('get_reservation'),
             status=200
         )
@@ -66,7 +66,7 @@ class TestScheduleCheckIn(unittest.TestCase):
 
         responses.add(
             responses.GET,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/record-locator/ABC123',
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/record-locator/ABC123',
             json=util.load_fixture('get_multi_passenger_reservation'),
             status=200
         )
@@ -94,7 +94,7 @@ class TestCheckIn(unittest.TestCase):
 
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/'
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/'
             'record-locator/ABC123/boarding-passes',
             json=util.load_fixture('check_in_success'),
             status=200
@@ -102,7 +102,7 @@ class TestCheckIn(unittest.TestCase):
 
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/record-locator/'
+            'https://mobile.southwest.com/api/extensions/v1/mobile/record-locator/'
             'ABC123/operation-infos/mobile-boarding-pass/notifications',
             json=util.load_fixture('email_boarding_pass'),
             status=200
@@ -127,7 +127,7 @@ class TestCheckIn(unittest.TestCase):
 
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/'
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/'
             'record-locator/ABC123/boarding-passes',
             json=util.load_fixture('check_in_success'),
             status=200
@@ -135,7 +135,7 @@ class TestCheckIn(unittest.TestCase):
 
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/record-locator/'
+            'https://mobile.southwest.com/api/extensions/v1/mobile/record-locator/'
             'ABC123/operation-infos/mobile-boarding-pass/notifications',
             json=util.load_fixture('email_boarding_pass'),
             status=200
@@ -163,7 +163,7 @@ class TestCheckIn(unittest.TestCase):
 
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/'
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/'
             'record-locator/ABC123/boarding-passes',
             json=util.load_fixture('check_in_success'),
             status=200
@@ -171,7 +171,7 @@ class TestCheckIn(unittest.TestCase):
 
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/record-locator/'
+            'https://mobile.southwest.com/api/extensions/v1/mobile/record-locator/'
             'ABC123/operation-infos/mobile-boarding-pass/notifications',
             json=util.load_fixture('email_boarding_pass'),
             status=200
@@ -194,7 +194,7 @@ class TestCheckIn(unittest.TestCase):
 
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/'
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/'
             'record-locator/ABC123/boarding-passes',
             json=util.load_fixture('check_in_reservation_cancelled'),
             status=404

--- a/lambda/tests/test_swa.py
+++ b/lambda/tests/test_swa.py
@@ -17,7 +17,7 @@ class TestRequest(unittest.TestCase):
             "X-Api-Key": swa.API_KEY,
             "Accept-Language": "en-US;q=1"
         }
-        expected_url = "https://api-extensions.southwest.com/v1/mobile/foo/123456/bar"
+        expected_url = "https://mobile.southwest.com/api/extensions/v1/mobile/foo/123456/bar"
         fake_data = {}
 
         _ = swa._make_request(  # NOQA
@@ -36,7 +36,7 @@ class TestRequest(unittest.TestCase):
             "X-Api-Key": swa.API_KEY,
             "Accept-Language": "en-US;q=1"
         }
-        expected_url = "https://api-extensions.southwest.com/v1/mobile/foo/123456/bar"
+        expected_url = "https://mobile.southwest.com/api/extensions/v1/mobile/foo/123456/bar"
         fake_data = {}
 
         _ = swa._make_request(  # NOQA
@@ -83,7 +83,7 @@ class TestCheckIn(unittest.TestCase):
     def test_check_in_success(self):
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/record-locator/ABC123/boarding-passes',
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/record-locator/ABC123/boarding-passes',
             json=util.load_fixture('check_in_success'),
             status=200
         )
@@ -95,7 +95,7 @@ class TestCheckIn(unittest.TestCase):
     def test_check_in_reservation_cancelled(self):
         responses.add(
             responses.POST,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/record-locator/ABC123/boarding-passes',
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/record-locator/ABC123/boarding-passes',
             json=util.load_fixture('check_in_reservation_cancelled'),
             status=404
         )
@@ -127,7 +127,7 @@ class TestReservation(unittest.TestCase):
     def test_from_passenger_info(self):
         responses.add(
             responses.GET,
-            'https://api-extensions.southwest.com/v1/mobile/reservations/record-locator/ABC123',
+            'https://mobile.southwest.com/api/extensions/v1/mobile/reservations/record-locator/ABC123',
             json=util.load_fixture('get_reservation'),
             status=200
         )


### PR DESCRIPTION
Fixes https://github.com/DavidWittman/serverless-southwest-check-in/issues/55

Url has changed from
`BASE_URL = "https://api-extensions.southwest.com/v1/mobile"`
to
`BASE_URL = "https://mobile.southwest.com/api/extensions/v1/mobile"`


