### PR TITLE
Fixing current = true in region

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,9 +1,10 @@
 provider "aws" {
   region = "us-east-1"
+  alias = "region"
 }
 
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {
-  current = true
+  provider = "aws.region"
 }


### PR DESCRIPTION
Fixing the region since current = true is deprecated and not working in latest versions of terraform.