### PR TITLE
Remove ReservationCancelledError

### DIFF
--- a/lambda/lib/exceptions.py
+++ b/lambda/lib/exceptions.py
@@ -2,10 +2,6 @@ class SouthwestAPIError(Exception):
     pass
 
 
-class ReservationCancelledError(Exception):
-    pass
-
-
 class ReservationNotFoundError(Exception):
     pass
 

--- a/lambda/lib/handlers/check_in.py
+++ b/lambda/lib/handlers/check_in.py
@@ -34,8 +34,8 @@ def main(event, context):
         resp = swa.check_in(passengers, confirmation_number)
         log.info("Checked in {} passengers!".format(len(passengers)))
         log.debug("Check-in response: {}".format(resp))
-    except exceptions.ReservationCancelledError:
-        log.error("Reservation {} has been cancelled".format(confirmation_number))
+    except exceptions.ReservationNotFoundError:
+        log.error("Reservation {} not found. It may have been cancelled".format(confirmation_number))
         return False
     except Exception as e:
         log.error("Error checking in: {}".format(e))

--- a/lambda/lib/swa.py
+++ b/lambda/lib/swa.py
@@ -131,7 +131,7 @@ def _make_request(path, data, content_type, method='post', check_status_code=Tru
             msg = response.reason
 
         if response.status_code == 404:
-            raise exceptions.ReservationCancelledError()
+            raise exceptions.ReservationNotFoundError()
 
         raise exceptions.SouthwestAPIError("status_code={} msg=\"{}\"".format(
             response.status_code, msg))

--- a/lambda/tests/test_swa.py
+++ b/lambda/tests/test_swa.py
@@ -99,7 +99,7 @@ class TestCheckIn(unittest.TestCase):
             json=util.load_fixture('check_in_reservation_cancelled'),
             status=404
         )
-        with self.assertRaises(exceptions.ReservationCancelledError):
+        with self.assertRaises(exceptions.ReservationNotFoundError):
             result = swa.check_in(self.names, self.confirmation_number)
 
     @mock.patch('lib.swa._make_request')


### PR DESCRIPTION
This naming was a little presumptuous, since the API returns 404 for a
variety of different things. Stick with ReservationNotFoundError and
adjust the error message when checking in.

Closes #50